### PR TITLE
Add --diff-to-file option

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -32,7 +32,7 @@ func applyCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also writes it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -62,7 +62,7 @@ func pruneCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Selects an environment from inline environments")
-	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also writes it to specified file")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -85,7 +85,7 @@ func deleteCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also writes it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -119,7 +119,7 @@ func diffCmd() *cli.Command {
 	cmd.Flags().BoolVarP(&opts.Summarize, "summarize", "s", false, "print summary of the differences, not the actual contents")
 	cmd.Flags().BoolVarP(&opts.WithPrune, "with-prune", "p", false, "include objects deleted from the configuration in the differences")
 	cmd.Flags().BoolVarP(&opts.ExitZero, "exit-zero", "z", false, "Exit with 0 even when differences are found.")
-	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also writes it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -32,6 +32,7 @@ func applyCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -61,6 +62,7 @@ func pruneCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Selects an environment from inline environments")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -83,6 +85,7 @@ func deleteCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -116,6 +119,7 @@ func diffCmd() *cli.Command {
 	cmd.Flags().BoolVarP(&opts.Summarize, "summarize", "s", false, "print summary of the differences, not the actual contents")
 	cmd.Flags().BoolVarP(&opts.WithPrune, "with-prune", "p", false, "include objects deleted from the configuration in the differences")
 	cmd.Flags().BoolVarP(&opts.ExitZero, "exit-zero", "z", false, "Exit with 0 even when differences are found.")
+	cmd.Flags().StringVar(&opts.DiffToFile, "diff-to-file", "", "Outputs diff as usual but also outputs it to specified file")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -88,14 +88,14 @@ Please upgrade kubectl to at least version 1.18.1.`)
 
 	// output diff to file if requested by command-line option
 	if opts.DiffToFile != "" {
-		WriteDiffToFile(opts.DiffToFile, d)
+		err = WriteDiffToFile(opts.DiffToFile, d)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	// summarize if there is non-empty diff
-	// and the summary was requested by command-line option
+	// summarize if there is non-empty diff and the summary was requested
+	// by command-line option
 	if d != nil && opts.Summarize {
 		return util.Diffstat(*d)
 	}

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -82,14 +82,21 @@ Please upgrade kubectl to at least version 1.18.1.`)
 		{differ: staticDiffAllDeleted, state: orphaned},
 	}.diff()
 
-	switch {
-	case err != nil:
+	if err != nil {
 		return nil, err
-	case d == nil:
-		return nil, nil
 	}
 
-	if opts.Summarize {
+	// output diff to file if requested by command-line option
+	if opts.DiffToFile != "" {
+		WriteDiffToFile(opts.DiffToFile, d)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// summarize if there is non-empty diff
+	// and the summary was requested by command-line option
+	if d != nil && opts.Summarize {
 		return util.Diffstat(*d)
 	}
 

--- a/pkg/kubernetes/difftofile.go
+++ b/pkg/kubernetes/difftofile.go
@@ -1,0 +1,35 @@
+package kubernetes
+
+import (
+	"github.com/pkg/errors"
+	"os"
+)
+
+// always create file for consistency
+func writeDiffToFile(path string, diff *string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if diff != nil {
+		_, err = f.WriteString(*diff)
+		if err != nil {
+			return err
+		}
+	}
+	return f.Close()
+}
+
+func WriteDiffToFile(path string, diff *string) error {
+	err := writeDiffToFile(path, diff)
+	if err != nil {
+		return errors.Wrap(err, "writting diff to file")
+	}
+	return nil
+}
+
+// helper to produce and empty file
+// when we get empty diff we should produce an empty file
+func TruncateDiffToFile(path string) error {
+	return WriteDiffToFile(path, nil)
+}

--- a/pkg/kubernetes/difftofile.go
+++ b/pkg/kubernetes/difftofile.go
@@ -5,14 +5,15 @@ import (
 	"os"
 )
 
-// always create file for consistency
-func writeDiffToFile(path string, diff *string) error {
+// Write string to file
+// Create empty file if passed string is nil
+func writeStringToFile(path string, str *string) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	if diff != nil {
-		_, err = f.WriteString(*diff)
+	if str != nil {
+		_, err = f.WriteString(*str)
 		if err != nil {
 			return err
 		}
@@ -21,15 +22,15 @@ func writeDiffToFile(path string, diff *string) error {
 }
 
 func WriteDiffToFile(path string, diff *string) error {
-	err := writeDiffToFile(path, diff)
+	err := writeStringToFile(path, diff)
 	if err != nil {
 		return errors.Wrap(err, "writting diff to file")
 	}
 	return nil
 }
 
-// helper to produce and empty file
-// when we get empty diff we should produce an empty file
-func TruncateDiffToFile(path string) error {
+// Helper to produce an empty file
+// When we get empty diff we should produce an empty file
+func TruncateDiffFile(path string) error {
 	return WriteDiffToFile(path, nil)
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -69,7 +69,7 @@ type DiffOpts struct {
 
 	// Set the diff-strategy. If unset, the value set in the spec is used
 	Strategy string
-	// Return diff as usual but also output diff to file
+	// Return diff as usual but also write it to a file
 	DiffToFile string
 }
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -69,6 +69,8 @@ type DiffOpts struct {
 
 	// Set the diff-strategy. If unset, the value set in the spec is used
 	Strategy string
+	// Return diff as usual but also output diff to file
+	DiffToFile string
 }
 
 // Info about the client, etc.

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/fatih/color"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/term"
@@ -45,7 +46,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	if len(orphaned) == 0 {
 		log.Println("Nothing found to prune.")
 		if opts.DiffToFile != "" {
-			err = kubernetes.TruncateDiffToFile(opts.DiffToFile)
+			err = kubernetes.TruncateDiffFile(opts.DiffToFile)
 			if err != nil {
 				return err
 			}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/fatih/color"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/kubernetes/client"

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -20,6 +20,8 @@ type ApplyOpts struct {
 	AutoApprove bool
 	// DiffStrategy to use for printing the diff before approval
 	DiffStrategy string
+	// DiffToFile also outputs diff to specified file
+	DiffToFile string
 
 	// Force ignores any warnings kubectl might have
 	Force bool
@@ -42,7 +44,10 @@ func Apply(baseDir string, opts ApplyOpts) error {
 	defer kube.Close()
 
 	// show diff
-	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
+	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{
+		Strategy: opts.DiffStrategy,
+		DiffToFile: opts.DiffToFile,
+	})
 	switch {
 	case err != nil:
 		// This is not fatal, the diff is not strictly required
@@ -89,6 +94,8 @@ func confirmPrompt(action, namespace string, info client.Info) error {
 type DiffOpts struct {
 	Opts
 
+	// DiffToFile also outputs diff to specified file
+	DiffToFile string
 	// Strategy must be one of "native", "validate", or "subset"
 	Strategy string
 	// Summarize prints a summary, instead of the actual diff
@@ -117,6 +124,7 @@ func Diff(baseDir string, opts DiffOpts) (*string, error) {
 	defer kube.Close()
 
 	return kube.Diff(l.Resources, kubernetes.DiffOpts{
+		DiffToFile: opts.DiffToFile,
 		Summarize: opts.Summarize,
 		Strategy:  opts.Strategy,
 		WithPrune: opts.WithPrune,
@@ -129,6 +137,8 @@ type DeleteOpts struct {
 
 	// AutoApprove skips the interactive approval
 	AutoApprove bool
+	// DiffToFile also outputs diff to specified file
+	DiffToFile string
 
 	// Force ignores any warnings kubectl might have
 	Force bool
@@ -155,7 +165,16 @@ func Delete(baseDir string, opts DeleteOpts) error {
 	diff, err := kubernetes.StaticDiffer(false)(l.Resources)
 
 	if err != nil {
-		fmt.Println("Error diffing:", err)
+		// static diff can't fail normally, so unlike in apply, this is fatal
+		// here
+		return errors.Wrap(err, "error diffing")
+	}
+
+	if opts.DiffToFile != "" {
+		err = kubernetes.WriteDiffToFile(opts.DiffToFile, diff)
+		if err != nil {
+			return err
+		}
 	}
 
 	// in case of non-fatal error diff may be nil

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -46,7 +46,7 @@ func Apply(baseDir string, opts ApplyOpts) error {
 
 	// show diff
 	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{
-		Strategy: opts.DiffStrategy,
+		Strategy:   opts.DiffStrategy,
 		DiffToFile: opts.DiffToFile,
 	})
 	switch {
@@ -126,9 +126,9 @@ func Diff(baseDir string, opts DiffOpts) (*string, error) {
 
 	return kube.Diff(l.Resources, kubernetes.DiffOpts{
 		DiffToFile: opts.DiffToFile,
-		Summarize: opts.Summarize,
-		Strategy:  opts.Strategy,
-		WithPrune: opts.WithPrune,
+		Summarize:  opts.Summarize,
+		Strategy:   opts.Strategy,
+		WithPrune:  opts.WithPrune,
 	})
 }
 


### PR DESCRIPTION
Add `--diff-to-file` option for following tk commands:
- diff
- apply
- prune
- delete

Diff is written to stdout/pager as usual. But it is also written to file provided via `--diff-to-file` option.
File is truncated when diff returns no differences.
When we encounter an error we do not guarantee that we update the file.
When we fail to write the diff to file we do not always abort the workflow (we usually do but `tk apply` is an exception - see explanation below).

Notably, when user runs `tk apply` and the diffing itself fails then tanka still allows the user to apply the changes. In such case, the diff file might not be updated (depending on the nature of the diffing error). This sounds dumb at first but it actually makes sense. Consider situation when you need to hotfix something but failing diff prevents you from applying changes. Theoretically, diffs should never fail for applyable changes. Practically, diffing performs kubectl dry run which is inherently more fragile than the apply. Imho this justifies the design decision to allow apply for changes that fail to diff.

Upstream issue: https://github.com/grafana/tanka/issues/588